### PR TITLE
fix precision loss for doubles

### DIFF
--- a/pyrapidjson/_pyrapidjson.cpp
+++ b/pyrapidjson/_pyrapidjson.cpp
@@ -134,9 +134,7 @@ _get_pyobj_from_array(rapidjson::Value::ConstValueIterator& doc,
         break;
     case rapidjson::kNumberType:
         if (doc->IsDouble()) {
-            char _tmp[100] = "";
-            sprintf(_tmp, "%lf", doc->GetDouble());
-            obj = PyFloat_FromDouble(atof(_tmp));
+            obj = PyFloat_FromDouble(doc->GetDouble());
         }
         else {
             obj = PyInt_FromLong(doc->GetInt64());


### PR DESCRIPTION
@hhatto: what was the reason for converting to string (with the implied
loss of precision) and back to double?
